### PR TITLE
Segfault fix

### DIFF
--- a/do_postgres/ext/do_postgres/do_postgres.c
+++ b/do_postgres/ext/do_postgres/do_postgres.c
@@ -820,7 +820,11 @@ static VALUE cCommand_execute_non_query(int argc, VALUE *argv[], VALUE self) {
   status = PQresultStatus(response);
 
   if ( status == PGRES_TUPLES_OK ) {
-    insert_id = INT2NUM(atoi(PQgetvalue(response, 0, 0)));
+    if (PQgetlength(response, 0, 0) == 0)  {
+      insert_id = Qnil;
+    } else {
+      insert_id = INT2NUM(atoi(PQgetvalue(response, 0, 0)));
+    }
     affected_rows = INT2NUM(atoi(PQcmdTuples(response)));
   }
   else if ( status == PGRES_COMMAND_OK ) {


### PR DESCRIPTION
I have a patch branch here with a small reliability fix for an issue that one of my work colleagues found wherein a part of the code assumes that when a status of PGRES_TUPLES_OK is returned, the tuple set is always not null. This is not actually the case as we have at least one valid instance wherein an INSERT with the RETURNING option will return a null result set due to triggers in the database. As far as I can determine, this is valid behavior on PostgreSQL's part.
