### PR TITLE
Bugfix for postgres timestamptz handling

### DIFF
--- a/data_objects/lib/data_objects/spec/typecast/time_spec.rb
+++ b/data_objects/lib/data_objects/spec/typecast/time_spec.rb
@@ -62,7 +62,7 @@ shared 'supporting Time' do
 
   end
 
-  describe 'writing an Time' do
+  describe 'writing a Time' do
 
     before do
       @reader = @connection.create_command("SELECT id FROM widgets WHERE release_datetime = ? ORDER BY id").execute_reader(Time.local(2008, 2, 14, 00, 31, 12))

--- a/do_postgres/ext/do_postgres/do_postgres.c
+++ b/do_postgres/ext/do_postgres/do_postgres.c
@@ -289,13 +289,12 @@ static VALUE parse_date_time(const char *date) {
 static VALUE parse_time(const char *date) {
 
   int year, month, day, hour, min, sec, usec, tokens;
-  char subsec[7];
+  float subsec;
 
   if (0 != strchr(date, '.')) {
     // right padding usec with 0. e.g. '012' will become 12000 microsecond, since Time#local use microsecond
-    sscanf(date, "%4d-%2d-%2d %2d:%2d:%2d.%s", &year, &month, &day, &hour, &min, &sec, subsec);
-    usec   = atoi(subsec);
-    usec  *= (int) pow(10, (6 - strlen(subsec)));
+    sscanf(date, "%4d-%2d-%2d %2d:%2d:%2d%f", &year, &month, &day, &hour, &min, &sec, &subsec);
+    usec = subsec*1000000;
   } else {
     tokens = sscanf(date, "%4d-%2d-%2d %2d:%2d:%2d", &year, &month, &day, &hour, &min, &sec);
     if (tokens == 3) {

--- a/do_postgres/spec/typecast/time_spec.rb
+++ b/do_postgres/spec/typecast/time_spec.rb
@@ -5,4 +5,29 @@ require 'data_objects/spec/typecast/time_spec'
 
 describe 'DataObjects::Postgres with Time' do
   behaves_like 'supporting Time'
+
+  describe 'timestamp subsecond handling' do
+    before do
+      @connection.create_command(<<-EOF).execute_non_query
+        update widgets set release_timestamp = '2010-12-15 14:32:08.49377-08' where id = 1
+      EOF
+      @connection.create_command(<<-EOF).execute_non_query
+        update widgets set release_timestamp = '2010-12-15 14:32:28.942694-08' where id = 2
+      EOF
+
+      @command = @connection.create_command("SELECT release_timestamp FROM widgets WHERE id < ? order by id")
+      @command.set_types(Time)
+      @reader = @command.execute_reader(3)
+      @reader.next!
+      @values = @reader.values
+    end
+
+    it 'should handle variable subsecond lengths properly' do
+      @values.first.should == Time.at(1292452328.49377)
+
+      @reader.next!
+      @values = @reader.values
+      @values.first.should == Time.at(1292452348.942694)
+    end
+  end
 end


### PR DESCRIPTION
This patch fixes an issue converting timestamptz columns into Time objects. 
Timestamptzs with five digits of sub-second precision (like 2010-12-15 14:32:08.49377-08) were previously shifted 2048 minutes into the past.
