### PR TITLE
reading DateTime with do_sqlite3

### DIFF
--- a/data_objects/lib/data_objects/ext/do_common.c
+++ b/data_objects/lib/data_objects/ext/do_common.c
@@ -209,8 +209,8 @@ VALUE parse_time(const char *date) {
 }
 
 VALUE parse_date_time(const char *date) {
-  static char const* const _fmt_datetime_tz_normal = "%4d-%2d-%2d %2d:%2d:%2d%3d:%2d";
-  static char const* const _fmt_datetime_tz_subsec = "%4d-%2d-%2d %2d:%2d:%2d.%*d%3d:%2d";
+  static char const* const _fmt_datetime_tz_normal = "%4d-%2d-%2d%*c%2d:%2d:%2d%3d:%2d";
+  static char const* const _fmt_datetime_tz_subsec = "%4d-%2d-%2d%*c%2d:%2d:%2d.%*d%3d:%2d";
   int tokens_read;
   const char *fmt_datetime;
 

--- a/data_objects/lib/data_objects/spec/shared/typecast/datetime_spec.rb
+++ b/data_objects/lib/data_objects/spec/shared/typecast/datetime_spec.rb
@@ -19,7 +19,7 @@ shared_examples_for 'supporting DateTime' do
     describe 'with manual typecasting' do
 
       before do
-        @command = @connection.create_command("SELECT release_date FROM widgets WHERE ad_description = ?")
+        @command = @connection.create_command("SELECT release_datetime FROM widgets WHERE ad_description = ?")
         @command.set_types(DateTime)
         @reader = @command.execute_reader('Buy this product now!')
         @reader.next!
@@ -36,7 +36,8 @@ shared_examples_for 'supporting DateTime' do
 
       it 'should return the correct result' do
         date = @values.first
-        Date.civil(date.year, date.mon, date.day).should == Date.civil(2008, 2, 14)
+        local_offset = Rational(Time.local(2008, 2, 14).utc_offset, 86400)
+        date.should == DateTime.civil(2008, 2, 14, 00, 31, 12, local_offset)
       end
 
     end


### PR DESCRIPTION
I've had a problem with reading `DateTime` objects when using the sqlite adapter, they were missing the time portion.

The problem was caused the sscanf expression in `parse_date_time` which did not account for the _T_ that is inserted after the date by `DateTime.to_s`.
