### PR TITLE
do_jdbc: Change DataObject::Command#debug to call DataObject::Connection#log

### DIFF
--- a/do_jdbc/src/main/java/data_objects/Command.java
+++ b/do_jdbc/src/main/java/data_objects/Command.java
@@ -625,9 +625,9 @@ public class Command extends DORubyObject {
       Ruby runtime = getRuntime();
       Connection connection_instance = (Connection) api.getInstanceVariable(this,
           "@connection");
-      RubyClass messageClass = runtime.getModule(DATA_OBJECTS_MODULE_NAME)
-        .getClass("Logger")
-        .loggerClass.getClass("Message");
+      RubyModule doModule  = runtime.getModule(DATA_OBJECTS_MODULE_NAME);
+      RubyClass loggerClass = doModule.getClass("Logger");
+      RubyClass messageClass = loggerClass.getClass("Message");
 
       IRubyObject loggerMsg  = messageClass.newInstance(runtime.getCurrentContext(),
           runtime.newString(logMessage),    // query


### PR DESCRIPTION
This commit fixes do_jdbc's debug method. In the case of do_mysql, "data_objects_debug" function use DataObject::Connection#log to output debug log. But do_jdbc's "debug" method use driverModule's logger.
Because of this difference, dm-rails could not send notification to LogSubscriber when using JRuby and do_jdbc.
