### PR TITLE
Fix spec_helper scoping in derby, h2, hsqldb

### DIFF
--- a/do_derby/spec/spec_helper.rb
+++ b/do_derby/spec/spec_helper.rb
@@ -135,51 +135,51 @@ module DataObjectsSpecHelpers
           1234,
           13.4)
       EOF
-
-      # Removed
-      #           image_data,
-      #           ad_image,
-      #           cad_drawing,
-      # XXX: figure out how to insert BLOBS
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set flags = 1 where id = 2
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set ad_description = NULL where id = 3
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set flags = NULL where id = 4
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set cost1 = NULL where id = 5
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set cost2 = NULL where id = 6
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set release_date = NULL where id = 7
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set release_datetime = NULL where id = 8
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set release_timestamp = NULL where id = 9
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set release_datetime = '2008-07-14 00:31:12' where id = 10
-      EOF
-
-      conn.close
     end
+
+    # Removed
+    #           image_data,
+    #           ad_image,
+    #           cad_drawing,
+    # XXX: figure out how to insert BLOBS
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set flags = 1 where id = 2
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set ad_description = NULL where id = 3
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set flags = NULL where id = 4
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set cost1 = NULL where id = 5
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set cost2 = NULL where id = 6
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set release_date = NULL where id = 7
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set release_datetime = NULL where id = 8
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set release_timestamp = NULL where id = 9
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set release_datetime = '2008-07-14 00:31:12' where id = 10
+    EOF
+
+    conn.close
 
   end
 end

--- a/do_h2/spec/spec_helper.rb
+++ b/do_h2/spec/spec_helper.rb
@@ -118,47 +118,47 @@ module DataObjectsSpecHelpers
           1234,
           13.4);
       EOF
-
-      ## TODO: change the hexadecimal examples
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set flags = true where id = 2
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set ad_description = NULL where id = 3
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set flags = NULL where id = 4
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set cost1 = NULL where id = 5
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set cost2 = NULL where id = 6
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set release_date = NULL where id = 7
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set release_datetime = NULL where id = 8
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set release_timestamp = NULL where id = 9
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set release_datetime = '2008-07-14 00:31:12' where id = 10
-      EOF
-
-      conn.close
     end
+
+    ## TODO: change the hexadecimal examples
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set flags = true where id = 2
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set ad_description = NULL where id = 3
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set flags = NULL where id = 4
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set cost1 = NULL where id = 5
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set cost2 = NULL where id = 6
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set release_date = NULL where id = 7
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set release_datetime = NULL where id = 8
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set release_timestamp = NULL where id = 9
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set release_datetime = '2008-07-14 00:31:12' where id = 10
+    EOF
+
+    conn.close
 
   end
 end

--- a/do_hsqldb/spec/spec_helper.rb
+++ b/do_hsqldb/spec/spec_helper.rb
@@ -119,46 +119,46 @@ module DataObjectsSpecHelpers
           1234,
           13.4);
       EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set flags = true where id = 2
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set ad_description = NULL where id = 3
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set flags = NULL where id = 4
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set cost1 = NULL where id = 5
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set cost2 = NULL where id = 6
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set release_date = NULL where id = 7
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set release_datetime = NULL where id = 8
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set release_timestamp = NULL where id = 9
-      EOF
-
-      conn.create_command(<<-EOF).execute_non_query
-        update widgets set release_datetime = '2008-07-14 00:31:12' where id = 10
-      EOF
-
-      ## TODO: change the hexadecimal examples
-      conn.close
     end
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set flags = true where id = 2
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set ad_description = NULL where id = 3
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set flags = NULL where id = 4
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set cost1 = NULL where id = 5
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set cost2 = NULL where id = 6
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set release_date = NULL where id = 7
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set release_datetime = NULL where id = 8
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set release_timestamp = NULL where id = 9
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      update widgets set release_datetime = '2008-07-14 00:31:12' where id = 10
+    EOF
+
+    ## TODO: change the hexadecimal examples
+    conn.close
 
   end
 end


### PR DESCRIPTION
I am writing an adapter for a new database and am basing it off of Derby.  I noticed that the scoping of the `1..upto(16)` block in the spec_helper seems to be off (`conn.close` is in the loop scope).  Hopefully I'm not missing something here, as the Derby specs seem to pass either way.
