### PR TITLE
Fixed problem with Postgres 9.1 Writeable CTE's

### DIFF
--- a/do_jdbc/src/main/java/data_objects/Command.java
+++ b/do_jdbc/src/main/java/data_objects/Command.java
@@ -147,10 +147,11 @@ public class Command extends DORubyObject {
 
             long startTime = System.currentTimeMillis();
             if (usePS) {
-                if (sqlText.contains("RETURNING") && !hasReturnParam) {
-                    keys = sqlStatement.executeQuery();
+                boolean hasResult = sqlStatement.execute();
+                if (hasResult) {
+                    keys = sqlStatement.getResultSet();
                 } else {
-                    affectedCount = sqlStatement.executeUpdate();
+                    affectedCount = sqlStatement.getUpdateCount();
                 }
             } else {
                 sqlSimpleStatement.execute(sqlText);

--- a/do_postgres/spec/command_spec.rb
+++ b/do_postgres/spec/command_spec.rb
@@ -6,4 +6,40 @@ require 'data_objects/spec/shared/command_spec'
 describe DataObjects::Postgres::Command do
   it_should_behave_like 'a Command'
   it_should_behave_like 'a Command with async'
+
+  describe 'query with RETURNING while not returning result' do
+    before do
+      @connection = DataObjects::Connection.new(CONFIG.uri)
+      @select_command = @connection.create_command("SELECT name FROM users WHERE id = 900")
+      @upsert_command = @connection.create_command("
+          WITH upsert AS
+            (UPDATE users SET name = ? WHERE id = 900 RETURNING id)
+          INSERT INTO users (id, name)
+          SELECT 900, 'dbussink' WHERE NOT EXISTS (SELECT 1 FROM upsert)")
+    end
+
+    after do
+      @connection.close
+    end
+
+    it "should work with a writable CTE acting as an Upsert" do
+      reader = @select_command.execute_reader
+      reader.to_a.size.should == 0
+      reader.close
+
+      @upsert_command.execute_non_query('jwkoelewijn')
+
+      reader = @select_command.execute_reader
+      reader.next!
+      reader.values[0].should == 'dbussink'
+      reader.close
+
+      @upsert_command.execute_non_query('jwkoelewijn')
+
+      reader = @select_command.execute_reader
+      reader.next!
+      reader.values[0].should == 'jwkoelewijn'
+      reader.close
+    end
+  end
 end


### PR DESCRIPTION
Problem solved by rewriting code that checked whether the
query should be executed using PreparedStatement#executeQuery() or
using PreparedStatement#executeUpdate().
Original code checked for the existence of the word 'RETURNING',
where this is perfectly possible in Postgres 9.1, where a writable
CTE can be created with the word RETURNING in it, while not actually
returning any values (i.e. #executeQuery() should have been called)

Fix is to use the PreparedStatement#execute(), which returns a
boolean that indicates whether a result was returned, or that
existing rows were affected. Based on the value of this boolean
either a ResultSet is requested or the number of affected rows
is retrieved.
