### PR TITLE
wrapped debug() with isDebug() so statementToString() is only called when needed.

### DIFF
--- a/do_jdbc/src/main/java/data_objects/Command.java
+++ b/do_jdbc/src/main/java/data_objects/Command.java
@@ -157,10 +157,12 @@ public class Command extends DORubyObject {
             }
             long endTime = System.currentTimeMillis();
 
-            if (usePS)
-                debug(driver.statementToString(sqlStatement), Long.valueOf(endTime - startTime));
-            else
-                debug(sqlText, Long.valueOf(endTime - startTime));
+            if (isDebug()) {
+              if (usePS)
+                  debug(driver.statementToString(sqlStatement), Long.valueOf(endTime - startTime));
+              else
+                  debug(sqlText, Long.valueOf(endTime - startTime));
+            }
 
             if (usePS && keys == null) {
                 if (driver.supportsJdbcGeneratedKeys()) {
@@ -256,8 +258,10 @@ public class Command extends DORubyObject {
             long startTime = System.currentTimeMillis();
             resultSet = sqlStatement.executeQuery();
             long endTime = System.currentTimeMillis();
-
-            debug(driver.statementToString(sqlStatement), Long.valueOf(endTime - startTime));
+ 
+            if (isDebug()) {
+                 debug(driver.statementToString(sqlStatement), Long.valueOf(endTime - startTime));
+            }
 
             metaData = resultSet.getMetaData();
             columnCount = metaData.getColumnCount();
@@ -642,4 +646,14 @@ public class Command extends DORubyObject {
         }
     }
 
+    /**
+     * returns if the debug mode is turned on.
+     */
+    private boolean isDebug() {
+        RubyModule driverModule = (RubyModule) getRuntime().getModule(
+                DATA_OBJECTS_MODULE_NAME).getConstant(driver.getModuleName());
+        IRubyObject logger = api.callMethod(driverModule, "logger");
+        int level = RubyNumeric.fix2int(api.callMethod(logger, "level"));
+        return level == 0;
+    }
 }


### PR DESCRIPTION
Was doing performance testing, data_objects.Command.execute_reader() was spending a lot of time in   statementToString(). 

Looks like it's only called to provide debug() information. So wrapped around a newly created isDebug() method.
