### PR TITLE
avoided dynamically creating class methods. Apparently, in JRuby at least, there is a lock on that.

### DIFF
--- a/data_objects/lib/data_objects/connection.rb
+++ b/data_objects/lib/data_objects/connection.rb
@@ -118,7 +118,7 @@ module DataObjects
 
     # Create a Command object of the right subclass using the given text
     def create_command(text)
-      concrete_command.new(self, text)
+      self.class.concrete_command.new(self, text)
     end
 
     def extension
@@ -135,6 +135,6 @@ module DataObjects
       @concrete_command ||= DataObjects::const_get(self.name.split('::')[-2]).const_get('Command')
     end
 
-
+  end
 
 end


### PR DESCRIPTION
I was testing with JDNI (Commons DBCP) with unlimited database connection. Might not be as bad if using DataMapper's connection pool. 
