### PR TITLE
Check if the Reader class is defined first, before defining it again.

### DIFF
--- a/do_jdbc/src/main/java/data_objects/Reader.java
+++ b/do_jdbc/src/main/java/data_objects/Reader.java
@@ -64,6 +64,12 @@ public class Reader extends DORubyObject {
         RubyClass superClass = doModule.getClass(RUBY_CLASS_NAME);
         RubyModule driverModule = (RubyModule) doModule.getConstant(driver
                 .getModuleName());
+        
+        IRubyObject readerConstant = driverModule.getConstantAt(RUBY_CLASS_NAME);
+        if (readerConstant instanceof RubyClass) {
+            return (RubyClass) readerConstant;
+        }
+
         RubyClass readerClass = driverModule.defineClassUnder(RUBY_CLASS_NAME,
                 superClass, READER_ALLOCATOR);
         readerClass.defineAnnotatedMethods(Reader.class);


### PR DESCRIPTION
Defining a class is pretty expensive. Only create if it's really needed.
