### PR TITLE
Set datestyle in postgres adapter

### DIFF
--- a/do_postgres/do_postgres.gemspec
+++ b/do_postgres/do_postgres.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{do_postgres}
-  s.version = "0.10.13"
+  s.version = "0.10.14.apsmod"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Dirkjan Bussink"]

--- a/do_postgres/ext/do_postgres/do_postgres.c
+++ b/do_postgres/ext/do_postgres/do_postgres.c
@@ -440,6 +440,7 @@ void do_postgres_full_connect(VALUE self, PGconn *db) {
   const char *backslash_off = "SET backslash_quote = off";
   const char *standard_strings_on = "SET standard_conforming_strings = on";
   const char *warning_messages = "SET client_min_messages = warning";
+  const char *date_format = "SET datestyle = ISO";
   VALUE r_options;
 
   r_options = rb_str_new2(backslash_off);
@@ -457,6 +458,13 @@ void do_postgres_full_connect(VALUE self, PGconn *db) {
   }
 
   r_options = rb_str_new2(warning_messages);
+  result = do_postgres_cCommand_execute(Qnil, self, db, r_options);
+
+  if (PQresultStatus(result) != PGRES_COMMAND_OK) {
+    rb_warn("%s", PQresultErrorMessage(result));
+  }
+
+  r_options = rb_str_new2(date_format);
   result = do_postgres_cCommand_execute(Qnil, self, db, r_options);
 
   if (PQresultStatus(result) != PGRES_COMMAND_OK) {

--- a/do_postgres/lib/do_postgres/version.rb
+++ b/do_postgres/lib/do_postgres/version.rb
@@ -1,5 +1,5 @@
 module DataObjects
   module Postgres
-    VERSION = '0.10.13'
+    VERSION = '0.10.14.apsmod'
   end
 end


### PR DESCRIPTION
I ran into an issue with postgres (actually enterprisedb) where datamapper didn't recognize the date format - forcing the datestyle to ISO is needed to fix the problem - see the attached change in do_postgres.c
