### PR TITLE
Update transaction.rb

### DIFF
--- a/data_objects/lib/data_objects/transaction.rb
+++ b/data_objects/lib/data_objects/transaction.rb
@@ -6,8 +6,8 @@ module DataObjects
 
   class Transaction
 
-    # The host name. Note, this relies on the host name being configured and resolvable using DNS
-    HOST = "#{Socket::gethostbyname(Socket::gethostname)[0]}" rescue "localhost"
+    # The local host name. Do not attempt to resolve in DNS to prevent potentially long delay
+    HOST = "#{Socket::gethostname}" rescue "localhost"
     @@counter = 0
 
     # The connection object allocated for this transaction


### PR DESCRIPTION
Do not lookup results of gethostname() in DNS as it often does not exist - either because it is a desktop or the external name is different. This can cause a fairly considerable delay in startup (the longest single Gem delay in our large Sinatra application found through file load instrumentation) which is quite noticeable during development or test automation
