### PR TITLE
Fix use-after-free in do_postgres_raise_error

### DIFF
--- a/do_postgres/ext/do_postgres/do_postgres.c
+++ b/do_postgres/ext/do_postgres/do_postgres.c
@@ -102,10 +102,11 @@ void do_postgres_raise_error(VALUE self, PGresult *result, VALUE query) {
   const char *message = PQresultErrorMessage(result);
   char *sql_state = PQresultErrorField(result, PG_DIAG_SQLSTATE);
   int postgres_errno = MAKE_SQLSTATE(sql_state[0], sql_state[1], sql_state[2], sql_state[3], sql_state[4]);
+  VALUE str = rb_str_new2(sql_state);
 
   PQclear(result);
 
-  data_objects_raise_error(self, do_postgres_errors, postgres_errno, message, query, rb_str_new2(sql_state));
+  data_objects_raise_error(self, do_postgres_errors, postgres_errno, message, query, str);
 }
 
 /* ====== Public API ======= */


### PR DESCRIPTION
The char\* returned by PQresultErrorField is freed by PQclear (see http://www.postgresql.org/docs/9.3/static/libpq-exec.html), so this is a use-after-free.  This causes a segfault on OpenBSD-current as free overwrites the memory with junk, both for security reasons and to detect programming errors like this.

I didn't actually test this (just edited the file on GitHub), but hopefully it works.  If not, I'm sure you'll be able to come up with a similar fix.
