### PR TITLE
Fix the jdbc-sqlite3 version

### DIFF
--- a/do_sqlite3/Gemfile
+++ b/do_sqlite3/Gemfile
@@ -5,7 +5,7 @@ path '../'
 gemspec
 
 platforms :jruby do
-  gem 'jdbc-sqlite3', '>=3.5.8'
+  gem 'jdbc-sqlite3', '~> 3.7.2'
   gem 'do_jdbc',      '0.10.14'
 end
 

--- a/do_sqlite3/tasks/compile.rake
+++ b/do_sqlite3/tasks/compile.rake
@@ -56,7 +56,7 @@ begin
     ext.debug     = ENV.has_key?('DO_JAVA_DEBUG') && ENV['DO_JAVA_DEBUG']
     ext.classpath = '../do_jdbc/lib/do_jdbc_internal.jar'
     ext.java_compiling do |gem|
-      gem.add_dependency 'jdbc-sqlite3', '>=3.5.8'
+      gem.add_dependency 'jdbc-sqlite3', '~> 3.7.2'
       gem.add_dependency 'do_jdbc',      '0.10.14'
     end
   end


### PR DESCRIPTION
New version of jdbc-sqlite3 has been released.
But If we're using datamapper with it, it won't work correctly.
see https://travis-ci.org/padrino/padrino-framework/jobs/41961426

Thanks.
