### PR TITLE
support for mysql utf8mb4 encoding

### DIFF
--- a/do_mysql/lib/do_mysql/encoding.rb
+++ b/do_mysql/lib/do_mysql/encoding.rb
@@ -20,6 +20,7 @@ module DataObjects
         "GBK"          => "gbk",
         "ISO-8859-9"   => "latin5",
         "UTF-8"        => "utf8",
+        "UTF-8-MB4"    => "utf8mb4",
         "UTF-16BE"     => "ucs2",
         "IBM866"       => "cp866",
         "macCentEuro"  => "macce",


### PR DESCRIPTION
added mapping for utf8mb4 encoding, which is supported by the underlying C driver and mysql.

http://dev.mysql.com/doc/refman/5.7/en/charset-unicode-utf8mb4.html