### PR TITLE
[do_postgress] Get ext to build on Ruby 2.0.0 (stock OS X).

### DIFF
--- a/do_postgres/ext/do_postgres/extconf.rb
+++ b/do_postgres/ext/do_postgres/extconf.rb
@@ -14,11 +14,21 @@ def pg_config(type)
   IO.popen("pg_config --#{type}").readline.chomp rescue nil
 end
 
+# The preheader argument wasn't introduced till Ruby 1.9.3.
+def have_header_with_preheader(header, preheader)
+  if method(:have_header).arity == -2
+    have_header(header, preheader)
+  else
+    have_header(header)
+  end
+end
+
 def have_build_env
   (have_library('pq') || have_library('libpq')) &&
   have_header('libpq-fe.h') && have_header('libpq/libpq-fs.h') &&
-  have_header('postgres.h') && have_header('mb/pg_wchar.h') &&
-  have_header('catalog/pg_type.h')
+  have_header('postgres.h') &&
+  have_header_with_preheader('mb/pg_wchar.h', 'postgres.h') &&
+  have_header_with_preheader('catalog/pg_type.h', 'postgres.h')
 end
 
 $CFLAGS << ' -UENABLE_NLS -DHAVE_GETTIMEOFDAY -DHAVE_CRYPT' if RUBY_PLATFORM =~ /mswin|mingw/


### PR DESCRIPTION
For some reason the `c.h` PG header is not being included when building on older Rubies. Explicitely adding the base `postgres.h` header which includes the `c.h` header fixes it.

Here are the build logs before and after https://gist.github.com/alloy/23a6b235d35a346f4415