### PR TITLE
Work with ruby 2.3's --enable-frozen-string-literal

### DIFF
--- a/data_objects/lib/data_objects/uri.rb
+++ b/data_objects/lib/data_objects/uri.rb
@@ -78,7 +78,7 @@ module DataObjects
 
     # Display this URI object as a string
     def to_s
-      string = ""
+      string = String.new
       string << "#{scheme}:"     if scheme
       string << "#{subscheme}:"  if subscheme
       string << '//'             if relative?


### PR DESCRIPTION
These changes are the minimal ones necessary to allow Sequel's specs
to pass. There may well be other changes that are required.