### PR TITLE
memory leak fix - rb_fd_term was missing

### DIFF
--- a/do_mysql/ext/do_mysql/do_mysql.c
+++ b/do_mysql/ext/do_mysql/do_mysql.c
@@ -166,10 +166,10 @@ MYSQL_RES *do_mysql_cCommand_execute_async(VALUE self, VALUE connection, MYSQL *
 
   int socket_fd = db->net.fd;
   rb_fdset_t rset;
+  rb_fd_init(&rset);
+  rb_fd_set(socket_fd, &rset);
 
   while (1) {
-    rb_fd_init(&rset);
-    rb_fd_set(socket_fd, &rset);
 
     retval = rb_thread_fd_select(socket_fd + 1, &rset, NULL, NULL, NULL);
 
@@ -185,6 +185,7 @@ MYSQL_RES *do_mysql_cCommand_execute_async(VALUE self, VALUE connection, MYSQL *
       break;
     }
   }
+  rb_fd_term(&rset);     /* free memory allocated with rb_fd_init above */
 
   retval = mysql_read_query_result(db);
   CHECK_AND_RAISE(retval, query);


### PR DESCRIPTION
Our production cloud application was leaking memory (about 240 MB per day).  It was determined to be in datamapper - 160 bytes per MySQL read access.  The problem is in do_mysql.c, where, if HAVE_RB_THREAD_FD_SELECT is defined (a newer version of Ruby, I believe), rb_fd_init is called (which ALLOCs memory), and rb_fd_term is never called.  If HAVE_RB_THREAD_FD_SELECT is not defined, then the rb_fd_init does not ALLOC memory, and rb_fd_term is defined as a no-op, so there is no harm in calling rb_fd_term in that case.  I have added the call to rb_fd_term in the correct place.
The two attached plots show the memory usage of our application over 7 days, the only difference being the with and without the patch.  We restarted our application half-way through the plot because we were about to run out of memory.
The patch passes all 163 'rake spec' tests.

![mem1](https://cloud.githubusercontent.com/assets/16808143/12470570/5b39e58e-bfc3-11e5-815b-aff99ad3b3f7.PNG)
![mem2](https://cloud.githubusercontent.com/assets/16808143/12470574/64df10a0-bfc3-11e5-8bf5-8324030a612f.PNG)
