### PR TITLE
Add support for MySQL 5.7

### DIFF
--- a/do_mysql/ext/do_mysql/extconf.rb
+++ b/do_mysql/ext/do_mysql/extconf.rb
@@ -80,6 +80,7 @@ have_func 'mysql_sqlstate', 'mysql.h'
 have_func 'mysql_get_ssl_cipher', 'mysql.h'
 have_func 'mysql_set_character_set', 'mysql.h'
 have_func 'mysql_get_server_version', 'mysql.h'
+have_func 'mysql_real_escape_string_quote', 'mysql.h'
 have_struct_member 'MYSQL_FIELD', 'charsetnr', 'mysql.h'
 
 have_func('rb_thread_fd_select')


### PR DESCRIPTION
This fails because the behavior for `mysql_real_escape_string` has changed in 5.7. This is documented in
https://dev.mysql.com/doc/refman/5.7/en/mysql-real-escape-string.html in the explicit Note there.

Because of this we need to switch to using `mysql_real_escape_string_quote` on 5.7. Also adding a guard for the failure code to return an exception that indicates people probably need
to recompile the extension agains a newer version.

Fixes #88