### PR TITLE
Fix rb_init_fd leak for do_mysql and do_postgres

### DIFF
--- a/do_mysql/ext/do_mysql/do_mysql.c
+++ b/do_mysql/ext/do_mysql/do_mysql.c
@@ -166,10 +166,10 @@ MYSQL_RES *do_mysql_cCommand_execute_async(VALUE self, VALUE connection, MYSQL *
 
   int socket_fd = db->net.fd;
   rb_fdset_t rset;
+  rb_fd_init(&rset);
+  rb_fd_set(socket_fd, &rset);
 
   while (1) {
-    rb_fd_init(&rset);
-    rb_fd_set(socket_fd, &rset);
 
     retval = rb_thread_fd_select(socket_fd + 1, &rset, NULL, NULL, NULL);
 
@@ -185,6 +185,7 @@ MYSQL_RES *do_mysql_cCommand_execute_async(VALUE self, VALUE connection, MYSQL *
       break;
     }
   }
+  rb_fd_term(&rset);     /* free memory allocated with rb_fd_init above */
 
   retval = mysql_read_query_result(db);
   CHECK_AND_RAISE(retval, query);

--- a/do_mysql/ext/do_mysql/do_mysql.c
+++ b/do_mysql/ext/do_mysql/do_mysql.c
@@ -174,6 +174,7 @@ MYSQL_RES *do_mysql_cCommand_execute_async(VALUE self, VALUE connection, MYSQL *
     retval = rb_thread_fd_select(socket_fd + 1, &rset, NULL, NULL, NULL);
 
     if (retval < 0) {
+      rb_fd_term(&rset);
       rb_sys_fail(0);
     }
 
@@ -185,7 +186,7 @@ MYSQL_RES *do_mysql_cCommand_execute_async(VALUE self, VALUE connection, MYSQL *
       break;
     }
   }
-  rb_fd_term(&rset);     /* free memory allocated with rb_fd_init above */
+  rb_fd_term(&rset);
 
   retval = mysql_read_query_result(db);
   CHECK_AND_RAISE(retval, query);


### PR DESCRIPTION
@dgrunberg I've cherry-picked your fix from #91 into this pull request and also added the same fix for the `do_postgres` driver. Thanks again for finding and fixing this bug!