### PR TITLE
Fix handling of UTF-8-MB4 with MySQL

### DIFF
--- a/do_mysql/ext/do_mysql/do_mysql.c
+++ b/do_mysql/ext/do_mysql/do_mysql.c
@@ -332,7 +332,11 @@ void do_mysql_full_connect(VALUE self, MYSQL *db) {
     }
     else {
 #ifdef HAVE_RUBY_ENCODING_H
-      rb_iv_set(self, "@encoding_id", INT2FIX(rb_enc_find_index(rb_str_ptr_readonly(encoding))));
+      const char* ruby_encoding = rb_str_ptr_readonly(encoding);
+      if (strcasecmp("UTF-8-MB4", ruby_encoding) == 0) {
+        ruby_encoding = "UTF-8";
+      }
+      rb_iv_set(self, "@encoding_id", INT2FIX(rb_enc_find_index(ruby_encoding)));
 #endif
 
       rb_iv_set(self, "@my_encoding", my_encoding);

--- a/do_mysql/spec/encoding_spec.rb
+++ b/do_mysql/spec/encoding_spec.rb
@@ -7,4 +7,39 @@ describe DataObjects::Mysql::Connection do
   it_should_behave_like 'a driver supporting different encodings'
   it_should_behave_like 'returning correctly encoded strings for the default database encoding'
   it_should_behave_like 'returning correctly encoded strings for the default internal encoding'
+
+  describe 'sets the character set through the URI' do
+    before do
+      @utf8mb4_connection = DataObjects::Connection.new("#{CONFIG.scheme}://#{CONFIG.user}:#{CONFIG.pass}@#{CONFIG.host}:#{CONFIG.port}#{CONFIG.database}?encoding=UTF-8-MB4")
+    end
+
+    after { @utf8mb4_connection.close }
+
+    it { @utf8mb4_connection.character_set.should == 'UTF-8-MB4' }
+
+    describe 'writing a multibyte String' do
+      it 'should write a multibyte String' do
+        @command = @utf8mb4_connection.create_command('INSERT INTO users_mb4 (name) VALUES(?)')
+        expect { @command.execute_non_query("😀") }.not_to raise_error(DataObjects::DataError)
+      end
+    end
+
+    describe 'reading a String' do
+      before do
+        @reader = @utf8mb4_connection.create_command("SELECT name FROM users_mb4").execute_reader
+        @reader.next!
+        @values = @reader.values
+      end
+
+      after do
+        @reader.close
+      end
+
+      it 'should return UTF-8 encoded String' do
+        @values.first.should be_kind_of(String)
+        @values.first.encoding.name.should == 'UTF-8'
+        @values.first.should == "😀"
+      end
+    end
+  end
 end

--- a/do_mysql/spec/spec_helper.rb
+++ b/do_mysql/spec/spec_helper.rb
@@ -63,6 +63,10 @@ module DataObjectsSpecHelpers
     EOF
 
     conn.create_command(<<-EOF).execute_non_query
+      DROP TABLE IF EXISTS `users_mb4`
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
       DROP TABLE IF EXISTS `stuff`
     EOF
 
@@ -77,6 +81,14 @@ module DataObjectsSpecHelpers
         `fired_at` timestamp,
         PRIMARY KEY  (`id`)
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+    EOF
+
+    conn.create_command(<<-EOF).execute_non_query
+      CREATE TABLE `users_mb4` (
+        `id` int(11) NOT NULL auto_increment,
+        `name` varchar(200),
+        PRIMARY KEY  (`id`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
     EOF
 
     conn.create_command(<<-EOF).execute_non_query


### PR DESCRIPTION
This would not properly tag the returned string as UTF-8 since it would not see UTF-8-MB4 as UTF-8 in Ruby land. Therefore it fell back to binary instead of the proper encoding.

Fixes #89