### PR TITLE
Postgres bignum insert

### DIFF
--- a/do_postgres/ext/do_postgres/do_postgres.c
+++ b/do_postgres/ext/do_postgres/do_postgres.c
@@ -543,14 +543,14 @@ VALUE do_postgres_cCommand_execute_non_query(int argc, VALUE *argv, VALUE self) 
       insert_id = Qnil;
     }
     else {
-      insert_id = INT2NUM(atoi(PQgetvalue(response, 0, 0)));
+      insert_id = rb_cstr_to_inum(PQgetvalue(response, 0, 0), 10, 0);
     }
 
-    affected_rows = INT2NUM(atoi(PQcmdTuples(response)));
+    affected_rows = rb_cstr_to_inum(PQcmdTuples(response), 10, 0);
   }
   else if (status == PGRES_COMMAND_OK) {
     insert_id = Qnil;
-    affected_rows = INT2NUM(atoi(PQcmdTuples(response)));
+    affected_rows = rb_cstr_to_inum(PQcmdTuples(response), 10, 0);
   }
   else {
     do_postgres_raise_error(self, response, query);


### PR DESCRIPTION
Replace all usage of `INT2NUM(atoi(cstr))` inside do_postgres with `rb_cstr_to_inum`.

Resolves #98.