### PR TITLE
Allow 1.9 series to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ rvm:
   - jruby-19mode
 matrix:
   allow_failures:
+    - rvm: 1.9.2
+    - rvm: 1.9.3
     - rvm: 1.8.7
     - rvm: ree
     - rvm: jruby-18mode


### PR DESCRIPTION
Travis has been failing because rake for 1.9.2 fails to install. 1.9 series is unsupported at this time. Let it fail.