### PR TITLE
Avoid Fixnum deprecation warning for Ruby 2.4

### DIFF
--- a/data_objects/lib/data_objects/pooling.rb
+++ b/data_objects/lib/data_objects/pooling.rb
@@ -146,7 +146,7 @@ module DataObjects
       attr_reader :used
 
       def initialize(max_size, resource, args)
-        raise ArgumentError.new("+max_size+ should be a Fixnum but was #{max_size.inspect}") unless Fixnum === max_size
+        raise ArgumentError.new("+max_size+ should be an Integer but was #{max_size.inspect}") unless Integer === max_size
         raise ArgumentError.new("+resource+ should be a Class but was #{resource.inspect}") unless Class === resource
 
         @max_size = max_size


### PR DESCRIPTION
Ruby 2.4 unifies Fixnum and Bignum into Integer.

For older versions this change would also accept Bignums instead of only Fixnums, but probably it wasn't intended to explicitly disallow Bignum values for `max_size` (number ranges for Fixnum/Bignum are platform dependent anyway).